### PR TITLE
REP-4496 Install gcc on Jenkins boxes

### DIFF
--- a/Puppetfile
+++ b/Puppetfile
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 #^syntax detection
 
-forge "http://forge.puppetlabs.com"
+forge "https://forgeapi.puppetlabs.com"
 
 # use dependencies defined in Modulefile
 #modulefile

--- a/myModules/repose_jenkins/manifests/init.pp
+++ b/myModules/repose_jenkins/manifests/init.pp
@@ -68,6 +68,11 @@ class repose_jenkins(
         ensure => present,
     }
 
+    package { 'gcc':
+        # This is needed by API-Checker's use of Nailgun
+        ensure => present,
+    }
+
 #jenkins master needs a git config so that it can talk to the scm plugin
 # Also needed by any of the release builds for when they do a git push
     file{ "${jenkins_home}/.gitconfig":


### PR DESCRIPTION
GCC is not installed by default on the new Ubuntu boxes and is now required by the API-Checker test suite which is now using Nailgun.