### PR TITLE
REP-4874 Update Repose infrastructure to fix publishing docs during Repose release builds

### DIFF
--- a/myModules/repose_jenkins/manifests/init.pp
+++ b/myModules/repose_jenkins/manifests/init.pp
@@ -39,6 +39,7 @@ class repose_jenkins(
     Class['firewall'] ~> Service['docker']
 
     $jenkins_home = '/var/lib/jenkins'
+    $github_key_info = hiera_hash("base::github_host_key", { "key" => "DEFAULT", "type" => "ssh-rsa" })
 
     class{"repose_gradle":
         user      => 'jenkins',
@@ -118,6 +119,14 @@ class repose_jenkins(
         shell      => '/bin/bash',
         managehome => true,
         require    => Group['docker'],
+    }
+
+    Sshkey<|title == 'github.com'|> {
+        ensure => present,
+        name   => $github_key_info["name"],
+        key    => $github_key_info["key"],
+        type   => $github_key_info["type"],
+        target => "${jenkins_home}/.ssh/known_hosts"
     }
 
     ssh_authorized_key { 'jenkins':


### PR DESCRIPTION
Turns out, the "github.com" ssh key entry is already present in the global ssh_known_hosts file. Our base module puts it there. Thus, I suspect that the Gradle plugin cloning the Git repository only uses the user's known hosts for some reason.

Anyway, it appears that Puppet has a built-in resource to handle this case – sshkey. Unfortunately, Puppet won't let you define multiple resources with the same title or alias. Pretty annoying when you want to set up the same key for multiple users. That's why I appended "-for-jenkins" to a couple of things.

Feel free to tell me that this is garbage.