### PR TITLE
REP-4873 Adding Docker networking to firewall

### DIFF
--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -2,9 +2,9 @@
 resources { "firewall":
     purge => true
 }
-resources { 'firewallchain':
-    purge => true,
-}
+# resources { 'firewallchain':
+#     purge => true,
+# }
 
 Firewall {
     before  => Class['base::fw_post'],

--- a/manifests/site.pp
+++ b/manifests/site.pp
@@ -2,6 +2,9 @@
 resources { "firewall":
     purge => true
 }
+resources { 'firewallchain':
+    purge => true,
+}
 
 Firewall {
     before  => Class['base::fw_post'],

--- a/myModules/repose_jenkins/manifests/init.pp
+++ b/myModules/repose_jenkins/manifests/init.pp
@@ -94,26 +94,26 @@ class repose_jenkins(
         chain    => 'FORWARD',
         outiface => 'docker0',
         ctstate  => ['RELATED', 'ESTABLISHED'],
-        jump     => 'ACCEPT',
+        action   => 'accept',
     }->
     firewall { '303 ACCEPT docker0 to not docker0 FORWARD':
         table    => 'filter',
         chain    => 'FORWARD',
         iniface  => 'docker0',
         outiface => '! docker0',
-        jump     => 'ACCEPT',
+        action   => 'accept',
     }->
     firewall { '304 ACCEPT docker0 to docker0 FORWARD':
         table    => 'filter',
         chain    => 'FORWARD',
         iniface  => 'docker0',
         outiface => 'docker0',
-        jump     => 'ACCEPT',
+        action   => 'accept',
     }->
     firewall { '305 RETURN DOCKER-ISOLATION':
-        table    => 'filter',
-        chain    => 'DOCKER-ISOLATION',
-        jump     => 'RETURN',
+        table => 'filter',
+        chain => 'DOCKER-ISOLATION',
+        jump  => 'RETURN',
     }
 
     $jenkins_home = '/var/lib/jenkins'

--- a/myModules/repose_jenkins/manifests/init.pp
+++ b/myModules/repose_jenkins/manifests/init.pp
@@ -46,12 +46,14 @@ class repose_jenkins(
     firewall { '200 route local through DOCKER':
         table    => 'nat',
         chain    => 'PREROUTING',
+        proto    => 'all',
         dst_type => 'LOCAL',
         jump     => 'DOCKER',
     }->
-    firewall { '201 OURPUT LOCAL through DOCKER':
+    firewall { '201 OUTPUT LOCAL through DOCKER':
         table       => 'nat',
         chain       => 'OUTPUT',
+        proto       => 'all',
         destination => '! 127.0.0.0/8',
         dst_type    => 'LOCAL',
         jump        => 'DOCKER',
@@ -59,6 +61,7 @@ class repose_jenkins(
     firewall { '202 MASQUERADE output interface not docker0':
         table    => 'nat',
         chain    => 'POSTROUTING',
+        proto    => 'all',
         source   => '172.17.0.0/16',
         outiface => '! docker0',
         jump     => 'MASQUERADE',
@@ -66,6 +69,7 @@ class repose_jenkins(
     firewall { '203 RETURN input interface docker0':
         table   => 'nat',
         chain   => 'DOCKER',
+        proto   => 'all',
         iniface => 'docker0',
         jump    => 'RETURN',
     }

--- a/myModules/repose_jenkins/manifests/init.pp
+++ b/myModules/repose_jenkins/manifests/init.pp
@@ -85,17 +85,20 @@ class repose_jenkins(
     firewall { '300 FORWARD to DOCKER-ISOLATION':
         table => 'filter',
         chain => 'FORWARD',
+        proto => 'all',
         jump  => 'DOCKER-ISOLATION',
     }->
     firewall { '301 route to docker0 through DOCKER':
         table    => 'filter',
         chain    => 'FORWARD',
+        proto    => 'all',
         outiface => 'docker0',
         jump     => 'DOCKER',
     }->
     firewall { '302 ACCEPT states to docker0 FORWARD':
         table    => 'filter',
         chain    => 'FORWARD',
+        proto    => 'all',
         outiface => 'docker0',
         ctstate  => ['RELATED', 'ESTABLISHED'],
         action   => 'accept',
@@ -103,6 +106,7 @@ class repose_jenkins(
     firewall { '303 ACCEPT docker0 to not docker0 FORWARD':
         table    => 'filter',
         chain    => 'FORWARD',
+        proto    => 'all',
         iniface  => 'docker0',
         outiface => '! docker0',
         action   => 'accept',
@@ -110,6 +114,7 @@ class repose_jenkins(
     firewall { '304 ACCEPT docker0 to docker0 FORWARD':
         table    => 'filter',
         chain    => 'FORWARD',
+        proto    => 'all',
         iniface  => 'docker0',
         outiface => 'docker0',
         action   => 'accept',
@@ -117,6 +122,7 @@ class repose_jenkins(
     firewall { '305 RETURN DOCKER-ISOLATION':
         table => 'filter',
         chain => 'DOCKER-ISOLATION',
+        proto => 'all',
         jump  => 'RETURN',
     }
 

--- a/myModules/repose_jenkins/manifests/init.pp
+++ b/myModules/repose_jenkins/manifests/init.pp
@@ -22,23 +22,12 @@ class repose_jenkins(
     # ensure docker is installed to verify releases
     include docker
 
-    # TODO: v Remove this v
-    # restart the Docker service when iptables rules are updated
-    #
+
     # Docker requires certain iptables rules to be setup for containers to
     # access the internet. Docker will automatically setup these rules when the
     # service is run. However, the firewall Puppet module will purge the rules
-    # that Docker set up whenever it runs. Restarting the Docker service after
-    # the iptables rules are purged should solve this issue.
-    #
-    # Ideally, the firewall module would be configured to set up the necessary
-    # Docker iptables rules. However, since Docker, by default, picks its own
-    # subnet on the host when it creates a bridge, we don't necessarily know
-    # what the iptables rules will look like when Puppet runs. This can probably
-    # be fixed by customizing the docker0 bridge, but that's a whole new chunk
-    # of work.
-    # Class['firewall'] ~> Service['docker']
-
+    # that Docker set up whenever it runs. Setting the iptables rules through
+    # the firewall module should solve this issue.
     firewallchain { 'DOCKER:nat:IPv4':
         ensure => 'present',
         purge  => 'true',

--- a/myModules/repose_jenkins/manifests/init.pp
+++ b/myModules/repose_jenkins/manifests/init.pp
@@ -20,8 +20,11 @@ class repose_jenkins(
     include repose_jenkins::gpgkey
 
     # ensure docker is installed to verify releases
-    include docker
+    class { 'docker':
+        bip => '172.17.0.0/16'
+    }
 
+    # TODO: v Remove this v
     # restart the Docker service when iptables rules are updated
     #
     # Docker requires certain iptables rules to be setup for containers to

--- a/myModules/repose_jenkins/manifests/init.pp
+++ b/myModules/repose_jenkins/manifests/init.pp
@@ -20,8 +20,8 @@ class repose_jenkins(
     include repose_jenkins::gpgkey
 
     # ensure docker is installed to verify releases
+    # TODO: Ensure the docker0 bridge matches the firewall rules below.
     include docker
-
 
     # Docker requires certain iptables rules to be setup for containers to
     # access the internet. Docker will automatically setup these rules when the

--- a/myModules/repose_jenkins/manifests/init.pp
+++ b/myModules/repose_jenkins/manifests/init.pp
@@ -21,7 +21,7 @@ class repose_jenkins(
 
     # ensure docker is installed to verify releases
     class { 'docker':
-        bip => '172.17.0.0/16'
+        bip => '172.12.0.0/16'
     }
 
     # TODO: v Remove this v
@@ -39,7 +39,7 @@ class repose_jenkins(
     # what the iptables rules will look like when Puppet runs. This can probably
     # be fixed by customizing the docker0 bridge, but that's a whole new chunk
     # of work.
-    Class['firewall'] ~> Service['docker']
+    # Class['firewall'] ~> Service['docker']
 
     $jenkins_home = '/var/lib/jenkins'
     $github_key_info = hiera_hash("base::github_host_key", { "key" => "DEFAULT", "type" => "ssh-rsa" })


### PR DESCRIPTION
So I tried setting the docker0 bridge to a static address, but did not succeed. All the things I tried ended up breaking Docker or the Docker Puppet module in some way. I'll probably keep poking at this trying to figure it out.

With that said, I believe that the default settings Docker uses are static, and will only change if:
- Docker updates and changes the default settings or behavior
- The IP Docker tries to use by default is already in use

As a result, what I have right now is working. It just sets the firewall settings to work with the default docker0 bridge.