### PR TITLE
Fixing metadata.json files

### DIFF
--- a/myModules/adrian_workstation/metadata.json
+++ b/myModules/adrian_workstation/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-adrian_workstation",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/backup_cloud_files/metadata.json
+++ b/myModules/backup_cloud_files/metadata.json
@@ -7,6 +7,6 @@
   "source": "",
   "dependencies": [
     {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
-    {"name":"stankevich/python","version_requirement":">= 0.0.1" }
+    {"name":"stankevich/python","version_requirement":">= 0.0.1"}
   ]
 }

--- a/myModules/backup_cloud_files/metadata.json
+++ b/myModules/backup_cloud_files/metadata.json
@@ -2,7 +2,11 @@
   "name": "repose-backup_cloud_files",
   "version": "0.0.1",
   "author": "David Kowis",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
   "dependencies": [
-    { "name": "stankevich/python", "version_requirement": ">= 0.0.1" }
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"stankevich/python","version_requirement":">= 0.0.1" }
   ]
 }

--- a/myModules/base/metadata.json
+++ b/myModules/base/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-base",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/basic_workstation/metadata.json
+++ b/myModules/basic_workstation/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-basic_workstation",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/cloud_monitoring/metadata.json
+++ b/myModules/cloud_monitoring/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-cloud_monitoring",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/joel_workstation/metadata.json
+++ b/myModules/joel_workstation/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-joel_workstation",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/mumble_server/metadata.json
+++ b/myModules/mumble_server/metadata.json
@@ -2,7 +2,11 @@
   "name": "repose-mumble_server",
   "version": "0.0.1",
   "author": "David Kowis",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
   "dependencies": [
-    { "name": "repose/backup_cloud_files", "version_requirement": ">= 0.0.1" }
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"repose/backup_cloud_files","version_requirement":">= 0.0.1"}
   ]
 }

--- a/myModules/puppet_master/metadata.json
+++ b/myModules/puppet_master/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-puppet_master",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/repose_gradle/metadata.json
+++ b/myModules/repose_gradle/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-repose_gradle",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/repose_groovy/metadata.json
+++ b/myModules/repose_groovy/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-repose_groovy",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/repose_idea/metadata.json
+++ b/myModules/repose_idea/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-repose_idea",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/repose_influxdb/metadata.json
+++ b/myModules/repose_influxdb/metadata.json
@@ -2,8 +2,11 @@
   "name": "repose-repose_influxdb",
   "version": "0.0.1",
   "author": "William Scheidegger",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 0.0.1" },
-    { "name": "repose/backup_cloud_files", "version_requirement": ">= 0.0.1" }
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"repose/backup_cloud_files","version_requirement":">= 0.0.1"}
   ]
 }

--- a/myModules/repose_jenkins/metadata.json
+++ b/myModules/repose_jenkins/metadata.json
@@ -2,10 +2,14 @@
   "name": "repose-repose_jenkins",
   "version": "0.0.1",
   "author": "David Kowis",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
   "dependencies": [
-    { "name": "puppetlabs/apt", "version_requirement": ">= 0.0.1" },
-    { "name": "camptocamp/archive", "version_requirement": ">= 0.0.1" },
-    { "name": "rtyler/jenkins", "version_requirement": ">= 1.3.0" },
-    { "name": "golja/gnupg", "version_requirement": ">= 0.0.1" }
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs/apt","version_requirement":">= 0.0.1"},
+    {"name":"camptocamp/archive","version_requirement":">= 0.0.1"},
+    {"name":"rtyler/jenkins","version_requirement":">= 1.3.0"},
+    {"name":"golja/gnupg","version_requirement":">= 0.0.1"}
   ]
 }

--- a/myModules/repose_maven/metadata.json
+++ b/myModules/repose_maven/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-repose_maven",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/repose_nagios/metadata.json
+++ b/myModules/repose_nagios/metadata.json
@@ -2,7 +2,11 @@
   "name": "repose-repose_nagios",
   "version": "0.0.1",
   "author": "David Kowis",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
   "dependencies": [
-    { "name": "leinaddm/htpasswd", "version_requirement": ">= 0.0.1" }
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"leinaddm/htpasswd","version_requirement":">= 0.0.1"}
   ]
 }

--- a/myModules/repose_nexus/metadata.json
+++ b/myModules/repose_nexus/metadata.json
@@ -2,8 +2,12 @@
   "name": "repose-repose_nexus",
   "version": "0.0.1",
   "author": "David Kowis",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
   "dependencies": [
-    { "name": "repose/backup_cloud_files", "version_requirement": ">= 0.0.1" },
-    { "name": "maestrodev/wget", "version_requirement": ">= 0.0.1" }
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"repose/backup_cloud_files","version_requirement":">= 0.0.1"},
+    {"name":"maestrodev/wget","version_requirement":">= 0.0.1"}
   ]
 }

--- a/myModules/repose_phone_home/metadata.json
+++ b/myModules/repose_phone_home/metadata.json
@@ -2,7 +2,11 @@
   "name": "repose-repose_phone_home",
   "version": "0.0.1",
   "author": "William Scheidegger",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
   "dependencies": [
-    { "name": "puppetlabs/mongodb", "version_requirement": ">= 0.0.1" }
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs/mongodb","version_requirement":">= 0.0.1"}
   ]
 }

--- a/myModules/repose_redirects/metadata.json
+++ b/myModules/repose_redirects/metadata.json
@@ -1,5 +1,11 @@
 {
   "name": "repose-repose_redirects",
   "version": "0.0.1",
-  "author": "David Kowis"
+  "author": "David Kowis",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/repose_sonar/metadata.json
+++ b/myModules/repose_sonar/metadata.json
@@ -2,10 +2,13 @@
   "name": "repose-repose_sonar",
   "version": "0.0.1",
   "author": "David Kowis",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">= 0.0.1" },
-    { "name": "puppetlabs/mysql", "version_requirement": ">= 0.0.1" },
-    { "name": "repose/backup_cloud_files", "version_requirement": ">= 0.0.1" },
-    { "name": "puppetlabs/java", "version_requirement": ">= 0.0.1" }
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"},
+    {"name":"puppetlabs/mysql","version_requirement":">= 0.0.1"},
+    {"name":"repose/backup_cloud_files","version_requirement":">= 0.0.1"},
+    {"name":"puppetlabs/java","version_requirement":">= 0.0.1"}
   ]
 }

--- a/myModules/ssl_cert/metadata.json
+++ b/myModules/ssl_cert/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-ssl_cert",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "",
+  "license": "Apache 2.0",
+  "source": "",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }

--- a/myModules/users/metadata.json
+++ b/myModules/users/metadata.json
@@ -1,4 +1,11 @@
 {
   "name": "repose-users",
-  "version": "0.0.1"
+  "version": "0.0.1",
+  "author": "repose",
+  "summary": "Sets up Repose team users.",
+  "license": "Apache 2.0",
+  "source": "https://github.com/rackerlabs/repose-infrastructure-ng/tree/master/myModules/users",
+  "dependencies": [
+    {"name":"puppetlabs-stdlib","version_requirement":">= 1.0.0"}
+  ]
 }


### PR DESCRIPTION
They were missing some required fields. Without those fields, the modules were not working.

From the Puppet docs:
> You also have the option of writing classes and defined types by hand and placing them in properly named manifest files as described in the “Module Layout” section above. If you take this route, you must ensure that your metadata.json file is properly formatted or your module will not work.