### PR TITLE
REP-4020 Fixing the ansible-galaxy command

### DIFF
--- a/myModules/repose_jenkins/manifests/performance_slave.pp
+++ b/myModules/repose_jenkins/manifests/performance_slave.pp
@@ -29,7 +29,7 @@ class repose_jenkins::performance_slave(
   }
 
   exec { 'Install Ansible Telegraf role':
-    command => 'ansible-galaxy install rossmcdonald.telegraf',
+    command => '/usr/local/bin/ansible-galaxy install rossmcdonald.telegraf',
   }
 
   file { "${repose_jenkins::jenkins_home}/.raxpub":


### PR DESCRIPTION
I did not fully qualify `ansible-galaxy` or provide a path. That's a requirement.