### PR TITLE
REP-5871 Extracted Duplicity target name to variable

### DIFF
--- a/myModules/repose_grafana/manifests/init.pp
+++ b/myModules/repose_grafana/manifests/init.pp
@@ -63,6 +63,8 @@ class repose_grafana {
   # schedule a clean up of the backups once a month
   cron { 'duplicity_cleanup':
     ensure   => present,
+    # escape the `\` and `$` characters so that neither Puppet nor the shell interpolate
+    # we literally want to pass `$url` as an argument to the Duplicity script
     command  => "$duplicityScript remove-older-than 1M --force \\\$url",
     user     => root,
     monthday => 1,

--- a/myModules/repose_grafana/manifests/init.pp
+++ b/myModules/repose_grafana/manifests/init.pp
@@ -63,7 +63,7 @@ class repose_grafana {
   # schedule a clean up of the backups once a month
   cron { 'duplicity_cleanup':
     ensure   => present,
-    command  => "$duplicityScript remove-older-than 1M --force \$url",
+    command  => "$duplicityScript remove-older-than 1M --force \\\$url",
     user     => root,
     monthday => 1,
     hour     => 3,

--- a/myModules/repose_influxdb/manifests/init.pp
+++ b/myModules/repose_influxdb/manifests/init.pp
@@ -146,7 +146,7 @@ class repose_influxdb (
 
   cron { 'duplicity_cleanup':
     ensure   => present,
-    command  => "$duplicityScript remove-older-than 30D --extra-clean --force \$url",
+    command  => "$duplicityScript remove-older-than 30D --extra-clean --force \\\$url",
     user     => root,
     hour     => 3,
     minute   => 0,

--- a/myModules/repose_influxdb/manifests/init.pp
+++ b/myModules/repose_influxdb/manifests/init.pp
@@ -146,6 +146,8 @@ class repose_influxdb (
 
   cron { 'duplicity_cleanup':
     ensure   => present,
+    # escape the `\` and `$` characters so that neither Puppet nor the shell interpolate
+    # we literally want to pass `$url` as an argument to the Duplicity script
     command  => "$duplicityScript remove-older-than 30D --extra-clean --force \\\$url",
     user     => root,
     hour     => 3,

--- a/myModules/repose_influxdb/manifests/init.pp
+++ b/myModules/repose_influxdb/manifests/init.pp
@@ -146,7 +146,7 @@ class repose_influxdb (
 
   cron { 'duplicity_cleanup':
     ensure   => present,
-    command  => "$duplicityScript remove-older-than 30D --extra-clean --force \$url"f,
+    command  => "$duplicityScript remove-older-than 30D --extra-clean --force \$url",
     user     => root,
     hour     => 3,
     minute   => 0,

--- a/myModules/repose_sonar/manifests/database.pp
+++ b/myModules/repose_sonar/manifests/database.pp
@@ -90,7 +90,7 @@ class repose_sonar::database(
 # schedule a clean up of the backups once a month
     cron{ 'duplicity_cleanup':
         ensure   => present,
-        command  => "$duplicityScript remove-older-than 1M --force \$url",
+        command  => "$duplicityScript remove-older-than 1M --force \\\$url",
         user     => root,
         monthday => 1,
         hour     => 3,

--- a/myModules/repose_sonar/manifests/database.pp
+++ b/myModules/repose_sonar/manifests/database.pp
@@ -66,7 +66,10 @@ class repose_sonar::database(
         time            => ['5', '0'],
     }
 
-    backup_cloud_files::target{ 'sonar_mysql':
+    $targetName = 'sonar_mysql'
+    $duplicityScript = "/usr/local/bin/duplicity_$targetName.rb"
+
+    backup_cloud_files::target{ $targetName :
         target            => '/srv/mysql-backups',
         cf_username       => hiera('rs_cloud_username'),
         cf_apikey         => hiera('rs_cloud_apikey'),
@@ -77,21 +80,21 @@ class repose_sonar::database(
 
     cron{ 'duplicity_backup':
         ensure  => present,
-        command => '/usr/local/bin/duplicity_sonar_mysql.rb',
+        command => $duplicityScript,
         user    => root,
         hour    => 6,
         minute  => 0,
-        require => Backup_cloud_files::Target['sonar_mysql'],
+        require => Backup_cloud_files::Target[$targetName],
     }
 
 # schedule a clean up of the backups once a month
     cron{ 'duplicity_cleanup':
         ensure   => present,
-        command  => '/usr/local/bin/duplicity_sonar_mysql.rb remove-older-than 1M --force \$url',
+        command  => "$duplicityScript remove-older-than 1M --force \$url",
         user     => root,
         monthday => 1,
         hour     => 3,
         minute   => 0,
-        require  => Backup_cloud_files::Target['sonar_mysql'],
+        require  => Backup_cloud_files::Target[$targetName],
     }
 }

--- a/myModules/repose_sonar/manifests/database.pp
+++ b/myModules/repose_sonar/manifests/database.pp
@@ -90,6 +90,8 @@ class repose_sonar::database(
 # schedule a clean up of the backups once a month
     cron{ 'duplicity_cleanup':
         ensure   => present,
+        # escape the `\` and `$` characters so that neither Puppet nor the shell interpolate
+        # we literally want to pass `$url` as an argument to the Duplicity script
         command  => "$duplicityScript remove-older-than 1M --force \\\$url",
         user     => root,
         monthday => 1,


### PR DESCRIPTION
I will note that I do not update the `mumble_server` manifest for two reasons:

1. It will no longer be in use soon (and may be deleted?).
1. The Duplicity script path is hard-coded in a Ruby file (which, in addition to calling the Duplicity script also backs up the database) rather than being called by Puppet directly. So to extract the same stuff, I would have to either template the Ruby script, or pull the Duplicity script execution out of it. Templating the Ruby script wouldn't be terrible, but it also does not seem particularly necessary given that we don't use Mumble anymore.