### PR TITLE
REP-6900 Revert "Downgrading Jacoco plugin to known working version"

### DIFF
--- a/myModules/repose_jenkins/manifests/master.pp
+++ b/myModules/repose_jenkins/manifests/master.pp
@@ -174,7 +174,7 @@ class repose_jenkins::master(
         version => '2.30',
       },
       'jacoco'                           => {
-        version => '2.2.1',
+        version => '3.0.1',
       },
       'jackson2-api'                     => {
         version => '2.8.11.1',


### PR DESCRIPTION
This reverts commit 1660ce1cd4072ffd0d37b9765bfbdf139a6091cd.

This requires https://github.com/rackerlabs/repose/pull/1927 to already be merged.