### PR TITLE
REP-6980 Tagging Performance Test Metrics with Repose Version

### DIFF
--- a/myModules/repose_influxdb/manifests/init.pp
+++ b/myModules/repose_influxdb/manifests/init.pp
@@ -62,9 +62,9 @@ class repose_influxdb (
       database             => $influxdb_performance_db,
       name-separator       => '_',
       templates            => [
-        "gatling.*.*.*.* measurement.measurement.request.status.field",
-        "gatling.*.users.*.* measurement.measurement.measurement.request.field",
-        "jmxtrans.* measurement.test_name..measurement.field",
+        "gatling.*.*.*.*.* measurement.repose_version.measurement.request.status.field",
+        "gatling.*.*.users.*.* measurement.repose_version.measurement.measurement.request.field",
+        "jmxtrans.* measurement.repose_version.test_name..measurement.field",
       ],
     },
     udp_options            => {


### PR DESCRIPTION
See also:
https://github.com/rackerlabs/repose/pull/1939