### PR TITLE
Updated Grafana from v5.1.3 to v5.1.4

### DIFF
--- a/myModules/repose_grafana/manifests/init.pp
+++ b/myModules/repose_grafana/manifests/init.pp
@@ -5,7 +5,7 @@ class repose_grafana {
 
   class { 'grafana':
     install_method => 'repo',
-    version        => '5.1.3',
+    version        => '5.1.4',
     cfg            => {
       app_mode         => 'production',
       users            => {


### PR DESCRIPTION
Looks like it was just a security update, and so, a minor version bump for us.

Release notes:
https://community.grafana.com/t/release-notes-v-5-1-x/6958