### PR TITLE
Updated the number of days Puppet Master reports are kept.

### DIFF
--- a/myModules/puppet_master/manifests/init.pp
+++ b/myModules/puppet_master/manifests/init.pp
@@ -109,7 +109,7 @@ class puppet_master {
 
     cron { 'reports_cleanup':
       ensure   => present,
-      command  => "find /var/lib/puppet/reports/ -type f -mtime +90 -name \"*.yaml\" -execdir rm -- {} +",
+      command  => "find /var/lib/puppet/reports/ -type f -mtime +60 -name \"*.yaml\" -execdir rm -- {} +",
       user     => root,
       hour     => 3,
       minute   => 0,


### PR DESCRIPTION
The value was lowered from 90 days down to 60 in order to prevent disk space notifications from Nagios.