### PR TITLE
Upgraded Grafana from v5.2.4 to v5.3.0

### DIFF
--- a/myModules/repose_grafana/manifests/init.pp
+++ b/myModules/repose_grafana/manifests/init.pp
@@ -5,7 +5,7 @@ class repose_grafana {
 
   class { 'grafana':
     install_method => 'repo',
-    version        => '5.2.4',
+    version        => '5.3.0',
     cfg            => {
       app_mode         => 'production',
       users            => {


### PR DESCRIPTION
Release notes can be found at:
https://github.com/grafana/grafana/releases

"Community" release notes can be found at:
https://community.grafana.com/t/release-notes-v5-3-x/10244