### PR TITLE
Upgraded Grafana from v5.3.2 to v5.3.4

### DIFF
--- a/myModules/repose_grafana/manifests/init.pp
+++ b/myModules/repose_grafana/manifests/init.pp
@@ -5,7 +5,7 @@ class repose_grafana {
 
   class { 'grafana':
     install_method => 'repo',
-    version        => '5.3.2',
+    version        => '5.3.4',
     cfg            => {
       app_mode         => 'production',
       users            => {


### PR DESCRIPTION
Release notes can be found at:
https://github.com/grafana/grafana/releases