### PR TITLE
Upgraded Grafana from v5.4.0 to v5.4.1

### DIFF
--- a/myModules/repose_grafana/manifests/init.pp
+++ b/myModules/repose_grafana/manifests/init.pp
@@ -5,7 +5,7 @@ class repose_grafana {
 
   class { 'grafana':
     install_method => 'repo',
-    version        => '5.4.0',
+    version        => '5.4.1',
     cfg            => {
       app_mode         => 'production',
       users            => {


### PR DESCRIPTION
Release notes can be found at:
https://github.com/grafana/grafana/releases