### PR TITLE
Fix docker error cpio: cap_set_file failed - Operation not supported

### DIFF
--- a/myModules/repose_jenkins/files/docker/daemon.json
+++ b/myModules/repose_jenkins/files/docker/daemon.json
@@ -1,0 +1,3 @@
+{
+    "storage-driver": "devicemapper"
+}

--- a/myModules/repose_jenkins/manifests/build_slave.pp
+++ b/myModules/repose_jenkins/manifests/build_slave.pp
@@ -123,4 +123,14 @@ class repose_jenkins::build_slave {
   python::pip { 'docutils':
     pkgname => 'docutils',
   }
+
+  file{ "/etc/docker/daemon.json":
+    ensure  => file,
+    mode    => '0644',
+    owner   => root,
+    group   => root,
+    source  => "puppet:///modules/repose_jenkins/docker/daemon.json",
+    notify => Service['docker'],
+  }
+
 }


### PR DESCRIPTION
Update docker to use devicemapper storage-driver to fix docker build error when building images under debian.